### PR TITLE
fix(NacosEventListener): 修复在容器中部署的时候,eureka会将自己的hostname取出来作为服务的hostname的问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.nacos</groupId>
     <artifactId>spring-cloud-nacos</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>pom</packaging>
 
     <name>Nacos Plus for Spring Cloud ${project.version}</name>

--- a/spring-cloud-nacos-proxy/pom.xml
+++ b/spring-cloud-nacos-proxy/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.nacos</groupId>
         <artifactId>spring-cloud-nacos</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-cloud-nacos-proxy/spring-cloud-nacos-config-proxy-example/pom.xml
+++ b/spring-cloud-nacos-proxy/spring-cloud-nacos-config-proxy-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.nacos</groupId>
         <artifactId>spring-cloud-nacos-proxy</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>net.nacos</groupId>
             <artifactId>spring-cloud-nacos-config-proxy</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba.nacos</groupId>

--- a/spring-cloud-nacos-proxy/spring-cloud-nacos-config-proxy/pom.xml
+++ b/spring-cloud-nacos-proxy/spring-cloud-nacos-config-proxy/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.nacos</groupId>
         <artifactId>spring-cloud-nacos-proxy</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-cloud-nacos-proxy/spring-cloud-nacos-eureka-proxy-example/pom.xml
+++ b/spring-cloud-nacos-proxy/spring-cloud-nacos-eureka-proxy-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.nacos</groupId>
         <artifactId>spring-cloud-nacos-proxy</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>net.nacos</groupId>
             <artifactId>spring-cloud-nacos-eureka-proxy</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba.nacos</groupId>

--- a/spring-cloud-nacos-proxy/spring-cloud-nacos-eureka-proxy/pom.xml
+++ b/spring-cloud-nacos-proxy/spring-cloud-nacos-eureka-proxy/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.nacos</groupId>
         <artifactId>spring-cloud-nacos-proxy</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-cloud-nacos-proxy/spring-cloud-nacos-eureka-proxy/src/main/java/net/nacos/eureka/sync/NacosEventListener.java
+++ b/spring-cloud-nacos-proxy/spring-cloud-nacos-eureka-proxy/src/main/java/net/nacos/eureka/sync/NacosEventListener.java
@@ -86,8 +86,7 @@ public class NacosEventListener implements EventListener {
     protected void register(Instance instance) {
         String appName = instance.getServiceName().substring(instance.getServiceName().lastIndexOf('@') + 1);
         String discoveryClient = instance.getMetadata().get(ProxyConstants.METADATA_DISCOVERY_CLIENT);
-        InetUtils.HostInfo hostInfo = inetUtils.findFirstNonLoopbackHostInfo();
-        String hostname = hostInfo.getHostname();
+        String hostname =instance.getIp();
 
         if (StringUtils.isEmpty(discoveryClient)) {
             Map<String, String> metadata = new HashMap<>(instance.getMetadata());


### PR DESCRIPTION
k8s部署时,k8s服务会自动给容器添加一条hosts,这个hostname在其他服务中是无法访问的,如10.42.1.182     deveureka-7f68f7c7fd-z87nf,因此使用服务的ip作为hostname,不会有问题;否则会出现网关转发给服务请求时,会去解析eureka的hostname,无法解析,或者服务间feigin调用的时候,也用这个错误的hostname,无法调用

错误例子:
```
java.net.UnknownHostException: Failed to resolve 'deveureka-dfb56fcc5-wgp8f' after 4 queries 
        at io.netty.resolver.dns.DnsResolveContext.finishResolve(DnsResolveContext.java:1047)
        Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
```

访问eureka的接口,http://ip/eureka/apps,hostName为eureka的hostname,此时服务间无法正常调用
```
<name>SOME-APP</name>
<instance>
<instanceId>some-app-549c48cd4d-ngmpz:some-app:18205</instanceId>
<hostName>deveureka-dfb56fcc5-wgp8f</hostName>
<app>SOME-APP</app>
<ipAddr>192.168.0.145</ipAddr>

```
修改代码后访问eureka的接口 ip/eureka/apps,hostName与ipAddr一致,可以正常使用
```
<name>SOME-APP</name>
<instance>
<instanceId>some-app-549c48cd4d-ngmpz:some-app:18205</instanceId>
<hostName>192.168.0.145</hostName>
<app>SOME-APP</app>
<ipAddr>192.168.0.145</ipAddr>

```